### PR TITLE
security: keep access token server-side only and redact secrets from logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Open `http://localhost:8083`.
 - `PORT`: server port (default `8083`)
 - `SECRET_KEY`: encryption key for `config.json` (default `newapi-sync-tool-2024`)
 - `CONFIG_DIR`: directory for `config.json` and `monitor-config.json` (default project root)
+- `ALLOWED_ORIGINS`: comma-separated CORS allowlist (e.g. `https://app.example.com`). When unset, all origins are allowed.
+
+## Security notes
+- The access token is **never** stored in the browser. It is sent to the server once, encrypted with `SECRET_KEY`, and stored in `config.json`. Subsequent requests omit the token and the server fills it in automatically (only for the matching server URL), so you enter it once.
+- **Set a strong random `SECRET_KEY`** (e.g. `SECRET_KEY=$(openssl rand -hex 32)`). With the default key, anyone who reads `config.json` can decrypt the token. The server prints a warning at startup when the default key is in use.
+- This tool has no built-in authentication. When exposing it publicly, place it behind an authenticated reverse proxy and set `ALLOWED_ORIGINS`.
 
 ## Docker
 ```bash

--- a/lib/NewAPIClient.js
+++ b/lib/NewAPIClient.js
@@ -563,7 +563,7 @@ class NewAPIClient {
             });
             
             console.log(`📊 渠道API响应状态: ${response.status}`);
-            console.log(`📄 渠道API原始响应:`, JSON.stringify(response.data, null, 2).substring(0, 500));
+            // 不打印原始响应体，避免渠道密钥(key)等敏感信息进入日志
             
             // 基于 gpt-api-sync 的响应格式解析
             if (response.data && response.data.success) {
@@ -703,7 +703,9 @@ class NewAPIClient {
                 ...(channelData.group !== undefined && { group: channelData.group })
             };
 
-            console.log(`🔄 更新渠道 ${channelData.id}, 修复后的数据结构:`, JSON.stringify(updatePayload, null, 2));
+            // 脱敏后再打印，避免上游渠道密钥(key)泄漏到日志
+            const safePayload = { ...updatePayload, key: updatePayload.key ? '***REDACTED***' : updatePayload.key };
+            console.log(`🔄 更新渠道 ${channelData.id}, 修复后的数据结构:`, JSON.stringify(safePayload, null, 2));
 
             const response = await this.client.put('/api/channel/', updatePayload);
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -52,6 +52,8 @@ class App {
       this.bindEvents();
       this.initModalScrollLock();
       this.loadSavedConfig();
+      // 从服务端读取已保存的配置状态（令牌仅存于服务端，不回传浏览器）
+      await this.loadServerConfig();
       this.initTheme();
       this.bindFeatureModules();
       this.initRulesList();  // 初始化规则列表
@@ -63,7 +65,7 @@ class App {
       this.checkUpdate();
 
       // 自动连接或跳转到设置
-      this.autoConnectOrRedirect();
+      await this.autoConnectOrRedirect();
 
     } catch (error) {
       console.error('❌ 初始化失败:', error);
@@ -119,22 +121,61 @@ class App {
     }
   }
 
-  async autoConnectOrRedirect() {
-    const saved = localStorage.getItem(STORAGE_KEYS.CONFIG);
-    if (saved) {
-      try {
-        const config = JSON.parse(saved);
-        if (config.baseUrl && config.token) {
-          console.log('🔄 检测到已保存配置，自动连接...');
-          // 延迟执行，确保 DOM 完全加载
-          setTimeout(() => {
-            this.connectAndLoadChannels();
-          }, 100);
-          return;
+  /**
+   * 从服务端读取已保存配置（仅返回 baseUrl/userId 等非敏感信息，不含令牌）。
+   * 令牌由服务端加密保存并在请求时自动补全，浏览器无需持有。
+   */
+  async loadServerConfig() {
+    try {
+      const res = await loadConfig();
+      const cfg = res && res.config;
+      if (res && res.success && cfg && cfg.hasConfig) {
+        state.hasServerConfig = true;
+        if (this.elements.baseUrl && !this.elements.baseUrl.value && cfg.baseUrl) {
+          this.elements.baseUrl.value = cfg.baseUrl;
         }
-      } catch (e) {
-        console.warn('配置解析失败:', e);
+        if (this.elements.userId && (!this.elements.userId.value || this.elements.userId.value === '1') && cfg.userId) {
+          this.elements.userId.value = cfg.userId;
+        }
+        state.config = {
+          ...state.config,
+          baseUrl: this.elements.baseUrl?.value || cfg.baseUrl || state.config.baseUrl,
+          userId: this.elements.userId?.value || cfg.userId || state.config.userId
+        };
+        if (this.elements.token && !this.elements.token.value) {
+          this.elements.token.placeholder = '已保存（服务器加密存储，无需重复输入）';
+        }
       }
+    } catch (e) {
+      console.warn('加载服务端配置失败:', e);
+    }
+  }
+
+  async autoConnectOrRedirect() {
+    let canAutoConnect = state.hasServerConfig === true;
+
+    // 兼容旧版本：localStorage 中可能仍残留 baseUrl（不再依赖其中的令牌）
+    if (!canAutoConnect) {
+      const saved = localStorage.getItem(STORAGE_KEYS.CONFIG);
+      if (saved) {
+        try {
+          const config = JSON.parse(saved);
+          if (config.baseUrl && config.token) {
+            canAutoConnect = true;
+          }
+        } catch (e) {
+          console.warn('配置解析失败:', e);
+        }
+      }
+    }
+
+    if (canAutoConnect) {
+      console.log('🔄 检测到已保存配置，自动连接...');
+      // 延迟执行，确保 DOM 完全加载
+      setTimeout(() => {
+        this.connectAndLoadChannels();
+      }, 100);
+      return;
     }
 
     // 没有有效配置，跳转到设置页面
@@ -686,12 +727,17 @@ class App {
       const saved = localStorage.getItem(STORAGE_KEYS.CONFIG);
       if (saved) {
         const config = { ...DEFAULT_CONFIG, ...JSON.parse(saved) };
+        // 迁移：清除旧版本遗留在 localStorage 中的明文令牌
+        if (Object.prototype.hasOwnProperty.call(JSON.parse(saved), 'token')) {
+          const { token, ...localConfig } = config;
+          localStorage.setItem(STORAGE_KEYS.CONFIG, JSON.stringify(localConfig));
+        }
         if (this.elements.baseUrl) this.elements.baseUrl.value = config.baseUrl || '';
-        if (this.elements.token) this.elements.token.value = config.token || '';
         if (this.elements.userId) this.elements.userId.value = config.userId || '1';
         if (this.elements.modelCacheRefreshMinutes) {
           this.elements.modelCacheRefreshMinutes.value = config.modelCacheRefreshMinutes || DEFAULT_CONFIG.modelCacheRefreshMinutes;
         }
+        // 令牌不再从浏览器恢复；保留旧 token 仅用于本次迁移期间的连续可用性
         state.config = config;
         this.applyModelCacheSettings(config);
       }
@@ -754,26 +800,39 @@ class App {
       cacheRefreshEl.value = config.modelCacheRefreshMinutes;
     }
 
-    if (!config.baseUrl || !config.token || !config.userId) {
+    const hasToken = !!config.token;
+
+    if (!config.baseUrl || !config.userId) {
       notifications.error('请填写完整的配置信息');
       return { success: false, message: '配置不完整' };
     }
+    // 服务端已保存令牌时允许留空（沿用已存令牌）；否则首次配置必须填写
+    if (!hasToken && !state.hasServerConfig) {
+      notifications.error('请填写访问令牌');
+      return { success: false, message: '缺少访问令牌' };
+    }
 
     try {
-      // 保存到本地存储
-      localStorage.setItem(STORAGE_KEYS.CONFIG, JSON.stringify(config));
+      // 仅在浏览器本地保存非敏感字段，访问令牌绝不写入 localStorage
+      const { token, ...localConfig } = config;
+      localStorage.setItem(STORAGE_KEYS.CONFIG, JSON.stringify(localConfig));
 
-      // 保存到服务器
-      const result = await saveConfig(config);
-      if (result.success) {
-        state.config = config;
-        this.applyModelCacheSettings(config);
-        notifications.success('配置已保存');
-        return { success: true };
-      } else {
-        notifications.error(`保存失败: ${result.message}`);
-        return { success: false, message: result.message };
+      // 仅当用户输入了新令牌时才提交到服务器（服务端 AES 加密存储）
+      if (hasToken) {
+        const result = await saveConfig(config);
+        if (!result.success) {
+          notifications.error(`保存失败: ${result.message}`);
+          return { success: false, message: result.message };
+        }
+        state.hasServerConfig = true;
       }
+
+      state.config = config;
+      this.applyModelCacheSettings(config);
+      if (hasToken) {
+        notifications.success('配置已保存');
+      }
+      return { success: true };
     } catch (error) {
       notifications.error(`保存失败: ${error.message}`);
       return { success: false, message: error.message };

--- a/public/js/core/state.js
+++ b/public/js/core/state.js
@@ -8,6 +8,8 @@ import { DEFAULT_CONFIG, CACHE_CONFIG, STORAGE_KEYS } from './constants.js';
 export const state = {
   // 配置
   config: { ...DEFAULT_CONFIG },
+  // 服务端是否已保存配置（令牌仅存于服务端，浏览器不持有）
+  hasServerConfig: false,
 
   // 数据
   channels: [],

--- a/public/js/features/sync/index.js
+++ b/public/js/features/sync/index.js
@@ -42,7 +42,8 @@ export const startSync = async (mode = 'append') => {
     return { success: false, message: '同步正在进行中' };
   }
 
-  if (!state.config.baseUrl || !state.config.token || !state.config.userId) {
+  // 令牌可由服务端加密存储并自动补全，浏览器侧不强制持有
+  if (!state.config.baseUrl || !state.config.userId || (!state.config.token && !state.hasServerConfig)) {
     notifications.error('请先配置连接信息');
     return { success: false, message: '请先配置连接信息' };
   }

--- a/server.js
+++ b/server.js
@@ -14,7 +14,9 @@ const CONFIG_DIR = process.env.CONFIG_DIR
   : __dirname;
 const CONFIG_FILE = path.join(CONFIG_DIR, 'config.json');
 const MONITOR_CONFIG_FILE = path.join(CONFIG_DIR, 'monitor-config.json');
-const SECRET_KEY = process.env.SECRET_KEY || 'newapi-sync-tool-2024';
+const DEFAULT_SECRET_KEY = 'newapi-sync-tool-2024';
+const SECRET_KEY = process.env.SECRET_KEY || DEFAULT_SECRET_KEY;
+const USING_DEFAULT_SECRET = SECRET_KEY === DEFAULT_SECRET_KEY;
 
 // Startup timestamp
 const startTime = Date.now();
@@ -242,7 +244,26 @@ const updateChannelSnapshot = async (context, channelData) => {
 };
 
 // Middlewares
-app.use(cors());
+// CORS: restrict to an explicit allowlist when ALLOWED_ORIGINS is set
+// (comma-separated). Defaults to the previous permissive behaviour so existing
+// deployments are unaffected, but exposing the API publicly should set this.
+const allowedOrigins = String(process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
+
+app.use(cors(allowedOrigins.length > 0
+  ? {
+    origin: (origin, callback) => {
+      // Allow same-origin / non-browser requests (no Origin header)
+      if (!origin || allowedOrigins.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error('Not allowed by CORS'));
+    }
+  }
+  : undefined));
+
 app.use(express.json({ charset: 'utf-8' }));
 app.use(express.urlencoded({ extended: true, charset: 'utf-8' }));
 app.use(express.static(path.join(__dirname, 'public')));
@@ -256,6 +277,55 @@ app.use((req, res, next) => {
 // Simple request logger
 app.use((req, res, next) => {
   console.log(`[${new Date().toISOString()}] ${req.method} ${req.path}`);
+  next();
+});
+
+// Read and decrypt the persisted config (returns null when absent/invalid).
+const getStoredConfig = async () => {
+  try {
+    const configData = await fs.readFile(CONFIG_FILE, 'utf8');
+    const encrypted = JSON.parse(configData);
+    return NewAPIClient.decryptConfig(encrypted, SECRET_KEY);
+  } catch (error) {
+    return null;
+  }
+};
+
+// Credential fallback: the access token is only ever persisted server-side
+// (AES-encrypted in config.json). The browser sends requests without a token,
+// and we fill it in from the stored config here. The stored token is injected
+// only when the request targets the same baseUrl it was saved for, so it can
+// never be leaked to a different server supplied by the client.
+app.use(async (req, res, next) => {
+  if (req.method === 'GET') return next();
+  if (!req.path.startsWith('/api/')) return next();
+  // /api/config saves credentials (needs the real token in the body) and
+  // /api/monitor/* uses its own stored config — skip both.
+  if (req.path === '/api/config' || req.path.startsWith('/api/monitor')) return next();
+
+  const src = req.body;
+  if (!src || typeof src !== 'object') return next();
+
+  const hasToken = src.token != null && String(src.token).trim() !== '';
+  if (hasToken) return next();
+
+  try {
+    const stored = await getStoredConfig();
+    if (!stored || !stored.token) return next();
+
+    // Only inject the stored token for its own server.
+    if (src.baseUrl && normalizeBaseUrl(src.baseUrl) !== normalizeBaseUrl(stored.baseUrl)) {
+      return next();
+    }
+
+    if (!src.baseUrl) src.baseUrl = stored.baseUrl;
+    if (!src.userId) src.userId = stored.userId;
+    if (src.authHeaderType == null && stored.authHeaderType) src.authHeaderType = stored.authHeaderType;
+    src.token = stored.token;
+  } catch (error) {
+    // Fall through with whatever the client supplied.
+  }
+
   next();
 });
 
@@ -284,11 +354,21 @@ app.get('/api/status', async (req, res) => {
 // Channel list endpoint (GET for frontend compatibility)
 app.get('/api/channel/', async (req, res) => {
   try {
-    const { baseUrl, token, userId, authHeaderType } = req.query;
+    let { baseUrl, token, userId, authHeaderType } = req.query;
+    // Fall back to the stored, server-side encrypted token when absent.
+    if (!token) {
+      const stored = await getStoredConfig();
+      if (stored && stored.token && (!baseUrl || normalizeBaseUrl(baseUrl) === normalizeBaseUrl(stored.baseUrl))) {
+        baseUrl = baseUrl || stored.baseUrl;
+        userId = userId || stored.userId;
+        authHeaderType = authHeaderType || stored.authHeaderType;
+        token = stored.token;
+      }
+    }
     if (!baseUrl || !token || !userId) {
       return res.status(400).json({ success: false, message: '请填写完整的配置信息' });
     }
-    
+
     const client = new NewAPIClient({ baseUrl, token, userId, authHeaderType });
     const requestedPageSize = req.query.pageSize || req.query.page_size;
     const result = await fetchAllChannels(client, requestedPageSize || 1000);
@@ -1315,6 +1395,14 @@ app.listen(PORT, async () => {
   console.log(`配置文件: ${CONFIG_FILE}`);
   console.log(`启动时间: ${new Date().toISOString()}`);
   console.log('按 CTRL+C 停止服务');
+
+  if (USING_DEFAULT_SECRET) {
+    console.warn('⚠️  [安全警告] 正在使用默认 SECRET_KEY，config.json 的加密形同虚设。');
+    console.warn('⚠️  请通过环境变量设置一个强随机 SECRET_KEY 后重启，例如: SECRET_KEY=$(openssl rand -hex 32)');
+  }
+  if (allowedOrigins.length === 0) {
+    console.warn('⚠️  [安全提示] 未设置 ALLOWED_ORIGINS，CORS 允许所有来源。公网部署时请设置 ALLOWED_ORIGINS 并置于带鉴权的反向代理之后。');
+  }
 
   // 尝试加载并启动定时监控
   try {


### PR DESCRIPTION
## 背景
代码审查发现若干敏感信息处理隐患（无恶意外传，均为防御性加固）。本 PR 让 **NewAPI 访问令牌只存于服务端（AES 加密），浏览器不再持有令牌**，并对日志、加密密钥、CORS 做加固。

## 改动
- **令牌不再进浏览器存储**：令牌仅在保存时提交到服务端并以 `SECRET_KEY` 加密写入 `config.json`；后续请求不带令牌，由服务端自动补全。补全**仅在请求的 `baseUrl` 与已存令牌所属服务器一致时**生效，避免把令牌发送到客户端指定的其他服务器。旧版本遗留在 `localStorage` 的明文令牌会在加载时清除。实现「输入一次，下次免输，且令牌不落浏览器」。
- **日志脱敏**：`updateChannel` 打印前对上游渠道 `key` 脱敏；移除对渠道接口原始响应体的整段打印。
- **默认密钥告警**：使用默认 `SECRET_KEY` 时启动告警（否则 `config.json` 加密形同虚设）。
- **CORS 收紧（opt-in）**：新增 `ALLOWED_ORIGINS` 允许列表，默认行为不变；未设置时启动提示。
- **文档**：README 增加安全说明与 `ALLOWED_ORIGINS` 说明。

## 验证
本地启动并验证：
1. `GET /api/config` 仅返回 `baseUrl/userId/hasConfig`，**不含令牌**；
2. 无令牌且 `baseUrl` 匹配 → 服务端自动补全令牌（正常进入连接流程）；
3. 无令牌但 `baseUrl` 不同 → 返回 400，**令牌不外泄**到其他服务器；
4. 磁盘上 `config.json` 为 AES 密文，无明文令牌；
5. 默认 `SECRET_KEY` 与未设置 `ALLOWED_ORIGINS` 时均有启动告警。

🤖 Generated with [Claude Code](https://claude.com/claude-code)